### PR TITLE
Fix copy-paste example on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ radar_visualization({
       moved: -1             // -1 = moved out (triangle pointing down)
                             //  0 = not moved (circle)
                             //  1 = moved in  (triangle pointing up)
-    },
-    ...
+   },
+    // ...
   ]
 });
 ```


### PR DESCRIPTION
Adds a comment prefix on a cosmetic line that was breaking the code when copy-pasted.

Also removes an extra blank space.