### PR TITLE
Add support for adding link to entries

### DIFF
--- a/docs/radar.js
+++ b/docs/radar.js
@@ -305,6 +305,14 @@ function radar_visualization(config) {
         legend.selectAll(".legend" + quadrant + ring)
           .data(segmented[quadrant][ring])
           .enter()
+            .append("a")
+                .attr("xlink:href", function (d, i) {
+                  return d.url ? "#" : null; // it's better to open new window so we provide # as url to stay on same page
+                })
+                .on("click", function (d) {
+                  // let's open new tab/window instead of redirecting off the radar
+                  window.open(d.url, "_blank");
+                })
             .append("text")
               .attr("transform", function(d, i) { return legend_transform(quadrant, ring, i); })
               .attr("class", "legend" + quadrant + ring)


### PR DESCRIPTION
First of all thanks for great OSS project 👍 . We are implementing our own radars, but having option to add URL link to specific entry will help our devs/colleagues to see more information (eg. our confluence page or public url)

By adding `xlink:href` will provide ability to add links to radar entries. Please let me know Your opinion or if You have any ideas how to make it better :).