### PR TITLE
Add links for technology entries.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -54,6 +54,7 @@ radar_visualization({
         ring: 0,
         label: "Spark",
         active: false,
+        link: "https://engineering.zalando.com/tags/apache-spark.html",
         moved: 0
       },
       {
@@ -75,6 +76,7 @@ radar_visualization({
         ring: 1,
         label: "Flink",
         active: false,
+        link: "https://engineering.zalando.com/tags/apache-flink.html",
         moved: 0
       },
       {
@@ -268,6 +270,7 @@ radar_visualization({
         ring: 0,
         label: "Node.js",
         active: false,
+        link: "https://engineering.zalando.com/tags/nodejs.html",
         moved: 0
       },
       {
@@ -318,6 +321,7 @@ radar_visualization({
         ring: 1,
         label: "Angular",
         active: false,
+        link: "https://engineering.zalando.com/tags/angular.html",
         moved: 0
       },
       {
@@ -538,6 +542,7 @@ radar_visualization({
         ring: 0,
         label: "Go",
         active: true,
+        link: "https://engineering.zalando.com/tags/golang.html",
         moved: 0
       },
       {
@@ -593,6 +598,7 @@ radar_visualization({
         ring: 3,
         label: "Clojure",
         active: true,
+        link: "https://engineering.zalando.com/tags/clojure.html",
         moved: -1
       },
       {
@@ -608,6 +614,7 @@ radar_visualization({
         ring: 3,
         label: "Haskell",
         active: true,
+        link: "https://engineering.zalando.com/tags/haskell.html",
         moved: -1
       },
       {
@@ -637,6 +644,7 @@ radar_visualization({
         ring: 3,
         label: "Rust",
         active: true,
+        link: "https://engineering.zalando.com/tags/rust.html",
         moved: -1
       },
       {
@@ -674,6 +682,7 @@ radar_visualization({
         ring: 1,
         label: "RabbitMQ",
         active: false,
+        link: "https://engineering.zalando.com/tags/rabbitmq.html",
         moved: 0
       },
       {

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,7 +47,6 @@ radar_visualization({
         ring: 0,
         label: "AWS EMR",
         active: false,
-        link: "../data_processing/aws_emr.html",
         moved: 0
       },
       {
@@ -55,7 +54,6 @@ radar_visualization({
         ring: 0,
         label: "Spark",
         active: false,
-        link: "../data_processing/spark.html",
         moved: 0
       },
       {
@@ -63,7 +61,6 @@ radar_visualization({
         ring: 1,
         label: "Airflow",
         active: false,
-        link: "../data_processing/airflow.html",
         moved: 0
       },
       {
@@ -71,7 +68,6 @@ radar_visualization({
         ring: 1,
         label: "AWS Data Pipeline",
         active: false,
-        link: "../data_processing/aws_data_pipeline.html",
         moved: 0
       },
       {
@@ -79,7 +75,6 @@ radar_visualization({
         ring: 1,
         label: "Flink",
         active: false,
-        link: "../data_processing/flink.html",
         moved: 0
       },
       {
@@ -87,7 +82,6 @@ radar_visualization({
         ring: 1,
         label: "Google BigQuery",
         active: false,
-        link: "../data_processing/google_bigquery.html",
         moved: 0
       },
       {
@@ -95,7 +89,6 @@ radar_visualization({
         ring: 1,
         label: "Presto",
         active: false,
-        link: "../data_processing/presto.html",
         moved: 0
       },
       {
@@ -103,7 +96,6 @@ radar_visualization({
         ring: 2,
         label: "Hadoop",
         active: false,
-        link: "../data_processing/hadoop.html",
         moved: 0
       },
       {
@@ -111,7 +103,6 @@ radar_visualization({
         ring: 2,
         label: "YARN",
         active: false,
-        link: "../data_processing/yarn.html",
         moved: 0
       },
       {
@@ -119,7 +110,6 @@ radar_visualization({
         ring: 3,
         label: "Esper",
         active: false,
-        link: "../data_processing/esper.html",
         moved: 0
       },
       {
@@ -127,7 +117,6 @@ radar_visualization({
         ring: 0,
         label: "AWS S3",
         active: false,
-        link: "../datastores/aws_s3.html",
         moved: 0
       },
       {
@@ -135,7 +124,7 @@ radar_visualization({
         ring: 0,
         label: "Cassandra",
         active: false,
-        link: "../datastores/cassandra.html",
+        link: "https://engineering.zalando.com/tags/cassandra.html",
         moved: 0
       },
       {
@@ -143,7 +132,7 @@ radar_visualization({
         ring: 0,
         label: "Elasticsearch",
         active: false,
-        link: "../datastores/elasticsearch.html",
+        link: "https://engineering.zalando.com/tags/elasticsearch.html",
         moved: 0
       },
       {
@@ -151,7 +140,6 @@ radar_visualization({
         ring: 0,
         label: "etcd",
         active: false,
-        link: "../datastores/etcd.html",
         moved: 0
       },
       {
@@ -159,7 +147,7 @@ radar_visualization({
         ring: 0,
         label: "PostgreSQL",
         active: false,
-        link: "../datastores/postgresql.html",
+        link: "https://engineering.zalando.com/tags/postgresql.html",
         moved: 0
       },
       {
@@ -167,7 +155,7 @@ radar_visualization({
         ring: 0,
         label: "Redis",
         active: false,
-        link: "../datastores/redis.html",
+        link: "https://engineering.zalando.com/tags/redis.html",
         moved: 0
       },
       {
@@ -175,7 +163,6 @@ radar_visualization({
         ring: 0,
         label: "Solr",
         active: false,
-        link: "../datastores/solr.html",
         moved: 0
       },
       {
@@ -183,7 +170,6 @@ radar_visualization({
         ring: 1,
         label: "AWS DynamoDB",
         active: false,
-        link: "../datastores/aws_dynamodb.html",
         moved: 0
       },
       {
@@ -191,7 +177,6 @@ radar_visualization({
         ring: 1,
         label: "HDFS",
         active: false,
-        link: "../datastores/hdfs.html",
         moved: 0
       },
       {
@@ -199,7 +184,6 @@ radar_visualization({
         ring: 2,
         label: "Consul",
         active: false,
-        link: "../datastores/consul.html",
         moved: 0
       },
       {
@@ -207,7 +191,6 @@ radar_visualization({
         ring: 2,
         label: "Google Bigtable",
         active: false,
-        link: "../datastores/google_bigtable.html",
         moved: 0
       },
       {
@@ -215,7 +198,6 @@ radar_visualization({
         ring: 2,
         label: "RocksDB",
         active: false,
-        link: "../datastores/rocksdb.html",
         moved: 0
       },
       {
@@ -223,7 +205,6 @@ radar_visualization({
         ring: 3,
         label: "Aerospike",
         active: false,
-        link: "../datastores/aerospike.html",
         moved: 0
       },
       {
@@ -231,7 +212,6 @@ radar_visualization({
         ring: 3,
         label: "CouchBase",
         active: false,
-        link: "../datastores/couchbase.html",
         moved: 0
       },
       {
@@ -239,7 +219,6 @@ radar_visualization({
         ring: 3,
         label: "HBase",
         active: false,
-        link: "../datastores/hbase.html",
         moved: 0
       },
       {
@@ -247,7 +226,6 @@ radar_visualization({
         ring: 3,
         label: "Memcached",
         active: false,
-        link: "../datastores/memcached.html",
         moved: 0
       },
       {
@@ -255,7 +233,6 @@ radar_visualization({
         ring: 3,
         label: "MongoDB",
         active: false,
-        link: "../datastores/mongodb.html",
         moved: 0
       },
       {
@@ -263,7 +240,6 @@ radar_visualization({
         ring: 3,
         label: "MySQL",
         active: false,
-        link: "../datastores/mysql.html",
         moved: 0
       },
       {
@@ -271,7 +247,6 @@ radar_visualization({
         ring: 3,
         label: "Oracle DB",
         active: false,
-        link: "../datastores/oracle_db.html",
         moved: 0
       },
       {
@@ -279,7 +254,6 @@ radar_visualization({
         ring: 3,
         label: "ZooKeeper",
         active: false,
-        link: "../datastores/zookeeper.html",
         moved: 0
       },
       {
@@ -287,7 +261,6 @@ radar_visualization({
         ring: 0,
         label: "Akka (Scala)",
         active: false,
-        link: "../frameworks/akka_scala.html",
         moved: 0
       },
       {
@@ -295,7 +268,6 @@ radar_visualization({
         ring: 0,
         label: "Node.js",
         active: false,
-        link: "../frameworks/nodejs.html",
         moved: 0
       },
       {
@@ -303,7 +275,6 @@ radar_visualization({
         ring: 0,
         label: "Play (Scala)",
         active: false,
-        link: "../frameworks/play_scala.html",
         moved: 0
       },
       {
@@ -311,7 +282,7 @@ radar_visualization({
         ring: 0,
         label: "ReactJS",
         active: false,
-        link: "../frameworks/reactjs.html",
+        link: "https://engineering.zalando.com/tags/react.html",
         moved: 0
       },
       {
@@ -319,7 +290,6 @@ radar_visualization({
         ring: 0,
         label: "RxJava (Android)",
         active: false,
-        link: "../frameworks/rxjava_android.html",
         moved: 0
       },
       {
@@ -327,7 +297,6 @@ radar_visualization({
         ring: 0,
         label: "scikit-learn",
         active: false,
-        link: "../frameworks/scikit_learn.html",
         moved: 0
       },
       {
@@ -335,7 +304,6 @@ radar_visualization({
         ring: 0,
         label: "Spring",
         active: false,
-        link: "../frameworks/spring.html",
         moved: 0
       },
       {
@@ -343,7 +311,6 @@ radar_visualization({
         ring: 1,
         label: "Akka-Http",
         active: false,
-        link: "../frameworks/akka_http.html",
         moved: 0
       },
       {
@@ -351,7 +318,6 @@ radar_visualization({
         ring: 1,
         label: "Angular",
         active: false,
-        link: "../frameworks/angular.html",
         moved: 0
       },
       {
@@ -359,7 +325,6 @@ radar_visualization({
         ring: 1,
         label: "AspectJ",
         active: false,
-        link: "../frameworks/aspectj.html",
         moved: 0
       },
       {
@@ -367,7 +332,6 @@ radar_visualization({
         ring: 1,
         label: "Camel",
         active: false,
-        link: "../frameworks/camel.html",
         moved: 0
       },
       {
@@ -375,7 +339,6 @@ radar_visualization({
         ring: 1,
         label: "Camunda",
         active: false,
-        link: "../frameworks/camunda.html",
         moved: 0
       },
       {
@@ -383,7 +346,6 @@ radar_visualization({
         ring: 1,
         label: "OpenNLP",
         active: false,
-        link: "../frameworks/opennlp.html",
         moved: 0
       },
       {
@@ -391,7 +353,6 @@ radar_visualization({
         ring: 1,
         label: "TensorFlow",
         active: false,
-        link: "../frameworks/tensorflow.html",
         moved: 0
       },
       {
@@ -399,7 +360,6 @@ radar_visualization({
         ring: 1,
         label: "Thymeleaf",
         active: false,
-        link: "../frameworks/thymeleaf.html",
         moved: 0
       },
       {
@@ -407,7 +367,6 @@ radar_visualization({
         ring: 2,
         label: "Aurelia",
         active: false,
-        link: "../frameworks/aurelia.html",
         moved: 0
       },
       {
@@ -415,7 +374,6 @@ radar_visualization({
         ring: 2,
         label: "Ember.js",
         active: false,
-        link: "../frameworks/emberjs.html",
         moved: 0
       },
       {
@@ -423,7 +381,6 @@ radar_visualization({
         ring: 2,
         label: "gRPC",
         active: false,
-        link: "../frameworks/grpc.html",
         moved: 0
       },
       {
@@ -431,7 +388,6 @@ radar_visualization({
         ring: 2,
         label: "Http4s",
         active: false,
-        link: "../frameworks/http4s.html",
         moved: 0
       },
       {
@@ -439,7 +395,6 @@ radar_visualization({
         ring: 2,
         label: "jOOQ",
         active: false,
-        link: "../frameworks/jooq.html",
         moved: 0
       },
       {
@@ -447,7 +402,6 @@ radar_visualization({
         ring: 2,
         label: "Redux",
         active: false,
-        link: "../frameworks/redux.html",
         moved: 0
       },
       {
@@ -455,7 +409,6 @@ radar_visualization({
         ring: 2,
         label: "Vert.x",
         active: false,
-        link: "../frameworks/vertx.html",
         moved: 0
       },
       {
@@ -463,7 +416,6 @@ radar_visualization({
         ring: 2,
         label: "Vue.js",
         active: false,
-        link: "../frameworks/vuejs.html",
         moved: 0
       },
       {
@@ -471,7 +423,6 @@ radar_visualization({
         ring: 3,
         label: "Activiti",
         active: false,
-        link: "../frameworks/activiti.html",
         moved: 0
       },
       {
@@ -479,7 +430,6 @@ radar_visualization({
         ring: 3,
         label: "AngularJS 1.x",
         active: false,
-        link: "../frameworks/angularjs_1x.html",
         moved: 0
       },
       {
@@ -487,7 +437,6 @@ radar_visualization({
         ring: 3,
         label: "BackboneJS",
         active: false,
-        link: "../frameworks/backbonejs.html",
         moved: 0
       },
       {
@@ -495,7 +444,6 @@ radar_visualization({
         ring: 3,
         label: "Drools",
         active: false,
-        link: "../frameworks/drools.html",
         moved: 0
       },
       {
@@ -503,7 +451,6 @@ radar_visualization({
         ring: 3,
         label: "Spray",
         active: false,
-        link: "../frameworks/spray.html",
         moved: 0
       },
       {
@@ -511,7 +458,7 @@ radar_visualization({
         ring: 0,
         label: "Docker",
         active: false,
-        link: "../infrastructure/docker.html",
+        link: "https://engineering.zalando.com/tags/docker.html",
         moved: 0
       },
       {
@@ -519,7 +466,6 @@ radar_visualization({
         ring: 0,
         label: "Hystrix",
         active: false,
-        link: "../infrastructure/hystrix.html",
         moved: 0
       },
       {
@@ -527,7 +473,7 @@ radar_visualization({
         ring: 0,
         label: "Kubernetes",
         active: false,
-        link: "../infrastructure/kubernetes.html",
+        link: "https://engineering.zalando.com/tags/kubernetes.html",
         moved: 0
       },
       {
@@ -535,7 +481,6 @@ radar_visualization({
         ring: 0,
         label: "Nginx",
         active: false,
-        link: "../infrastructure/nginx.html",
         moved: 0
       },
       {
@@ -543,7 +488,6 @@ radar_visualization({
         ring: 0,
         label: "OpenTracing",
         active: false,
-        link: "../infrastructure/opentracing.html",
         moved: 1
       },
       {
@@ -551,7 +495,6 @@ radar_visualization({
         ring: 0,
         label: "Tomcat",
         active: false,
-        link: "../infrastructure/tomcat.html",
         moved: 0
       },
       {
@@ -559,7 +502,6 @@ radar_visualization({
         ring: 0,
         label: "ZMON",
         active: false,
-        link: "../infrastructure/zmon.html",
         moved: 0
       },
       {
@@ -567,7 +509,6 @@ radar_visualization({
         ring: 1,
         label: "Failsafe",
         active: false,
-        link: "../infrastructure/failsafe.html",
         moved: 0
       },
       {
@@ -575,7 +516,6 @@ radar_visualization({
         ring: 1,
         label: "Undertow",
         active: false,
-        link: "../infrastructure/undertow.html",
         moved: 0
       },
       {
@@ -583,7 +523,6 @@ radar_visualization({
         ring: 2,
         label: "AWS Lambda",
         active: false,
-        link: "../infrastructure/aws_lambda.html",
         moved: 0
       },
       {
@@ -591,7 +530,7 @@ radar_visualization({
         ring: 3,
         label: "STUPS",
         active: false,
-        link: "../infrastructure/stups.html",
+        link: "https://engineering.zalando.com/tags/stups.html",
         moved: -1
       },
       {
@@ -599,7 +538,6 @@ radar_visualization({
         ring: 0,
         label: "Go",
         active: true,
-        link: "go.html",
         moved: 0
       },
       {
@@ -607,7 +545,7 @@ radar_visualization({
         ring: 0,
         label: "Java",
         active: true,
-        link: "java.html",
+        link: "https://engineering.zalando.com/tags/java.html",
         moved: 0
       },
       {
@@ -615,7 +553,7 @@ radar_visualization({
         ring: 0,
         label: "JavaScript",
         active: true,
-        link: "javascript.html",
+        link: "https://engineering.zalando.com/tags/javascript.html",
         moved: 0
       },
       {
@@ -623,7 +561,7 @@ radar_visualization({
         ring: 0,
         label: "OpenAPI (Swagger)",
         active: true,
-        link: "openapi_swagger.html",
+        link: "https://engineering.zalando.com/tags/openapi.html",
         moved: 0
       },
       {
@@ -631,7 +569,7 @@ radar_visualization({
         ring: 0,
         label: "Python",
         active: true,
-        link: "python.html",
+        link: "https://engineering.zalando.com/tags/python.html",
         moved: 0
       },
       {
@@ -639,7 +577,7 @@ radar_visualization({
         ring: 0,
         label: "Scala",
         active: true,
-        link: "scala.html",
+        link: "https://engineering.zalando.com/tags/scala.html",
         moved: 0
       },
       {
@@ -647,7 +585,7 @@ radar_visualization({
         ring: 0,
         label: "Swift",
         active: true,
-        link: "swift.html",
+        link: "https://engineering.zalando.com/tags/swift.html",
         moved: 0
       },
       {
@@ -655,7 +593,6 @@ radar_visualization({
         ring: 3,
         label: "Clojure",
         active: true,
-        link: "clojure.html",
         moved: -1
       },
       {
@@ -663,7 +600,7 @@ radar_visualization({
         ring: 1,
         label: "GraphQL",
         active: true,
-        link: "graphql.html",
+        link: "https://engineering.zalando.com/tags/graphql.html",
         moved: 1
       },
       {
@@ -671,7 +608,6 @@ radar_visualization({
         ring: 3,
         label: "Haskell",
         active: true,
-        link: "haskell.html",
         moved: -1
       },
       {
@@ -679,7 +615,6 @@ radar_visualization({
         ring: 1,
         label: "Kotlin",
         active: true,
-        link: "kotlin.html",
         moved: 0
       },
       {
@@ -687,7 +622,7 @@ radar_visualization({
         ring: 1,
         label: "TypeScript",
         active: true,
-        link: "typescript.html",
+        link: "https://engineering.zalando.com/tags/typescript.html",
         moved: 0
       },
       {
@@ -695,7 +630,6 @@ radar_visualization({
         ring: 2,
         label: "R",
         active: true,
-        link: "r.html",
         moved: 0
       },
       {
@@ -703,7 +637,6 @@ radar_visualization({
         ring: 3,
         label: "Rust",
         active: true,
-        link: "rust.html",
         moved: -1
       },
       {
@@ -711,7 +644,6 @@ radar_visualization({
         ring: 0,
         label: "AWS SNS",
         active: false,
-        link: "../queues/aws_sns.html",
         moved: 0
       },
       {
@@ -719,7 +651,6 @@ radar_visualization({
         ring: 0,
         label: "AWS SQS",
         active: false,
-        link: "../queues/aws_sqs.html",
         moved: 0
       },
       {
@@ -727,7 +658,7 @@ radar_visualization({
         ring: 0,
         label: "Kafka",
         active: false,
-        link: "../queues/kafka.html",
+        link: "https://engineering.zalando.com/tags/kafka.html",
         moved: 0
       },
       {
@@ -735,7 +666,7 @@ radar_visualization({
         ring: 0,
         label: "Nakadi",
         active: false,
-        link: "../queues/nakadi.html",
+        link: "https://nakadi.io",
         moved: 0
       },
       {
@@ -743,7 +674,6 @@ radar_visualization({
         ring: 1,
         label: "RabbitMQ",
         active: false,
-        link: "../queues/rabbitmq.html",
         moved: 0
       },
       {
@@ -751,7 +681,6 @@ radar_visualization({
         ring: 2,
         label: "AWS Kinesis",
         active: false,
-        link: "../queues/aws_kinesis.html",
         moved: 0
       },
       {
@@ -759,7 +688,6 @@ radar_visualization({
         ring: 3,
         label: "ActiveMQ",
         active: false,
-        link: "../queues/activemq.html",
         moved: 0
       },
       {
@@ -767,7 +695,6 @@ radar_visualization({
         ring: 3,
         label: "HornetQ",
         active: false,
-        link: "../queues/hornetq.html",
         moved: 0
       },
   ]

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -306,12 +306,8 @@ function radar_visualization(config) {
           .data(segmented[quadrant][ring])
           .enter()
             .append("a")
-                .attr("xlink:href", function (d, i) {
-                  return d.url ? "#" : null; // it's better to open new window so we provide # as url to stay on same page
-                })
-                .on("click", function (d) {
-                  // let's open new tab/window instead of redirecting off the radar
-                  window.open(d.url, "_blank");
+                .attr("href", function (d, i) {
+                  return d.link ? d.link : "#"; // stay on same page if no link was provided
                 })
             .append("text")
               .attr("transform", function(d, i) { return legend_transform(quadrant, ring, i); })


### PR DESCRIPTION
Use standard `href` attribute to support links for entries (legend) and update Zalando links to something meaningful.

Replaces #63.