### PR TITLE
Cleanup/enhancenments to links

### DIFF
--- a/docs/radar.js
+++ b/docs/radar.js
@@ -306,9 +306,14 @@ function radar_visualization(config) {
           .data(segmented[quadrant][ring])
           .enter()
             .append("a")
-                .attr("href", function (d, i) {
-                  return d.link ? d.link : "#"; // stay on same page if no link was provided
-                })
+              // Add an href if (and only if) there is a link
+              .attr("href", function (d, i) {
+                 return d.link ? d.link : null;
+              })
+              // Add a target if (and only if) there is a link and we want new tabs
+              .attr("target", function (d, i) {
+                 return (d.link && config.links_in_new_tabs) ? "_blank" : null;
+              })
             .append("text")
               .attr("transform", function(d, i) { return legend_transform(quadrant, ring, i); })
               .attr("class", "legend" + quadrant + ring)
@@ -397,9 +402,13 @@ function radar_visualization(config) {
     var blip = d3.select(this);
 
     // blip link
-    if (!config.print_layout && d.active && d.hasOwnProperty("link")) {
+    if (d.active && d.hasOwnProperty("link") && d.link) {
       blip = blip.append("a")
         .attr("xlink:href", d.link);
+
+      if (config.links_in_new_tabs) {
+        blip.attr("target", "_blank");
+      }
     }
 
     // blip shape


### PR DESCRIPTION
This changes a few things about links:
1. Links are now always enabled for blips
   Previously, it was only enabled for blips if there is
   no legend (config.print_layout = true)
2. hrefs are only added if there is actually a link
   Previously, there were always href created--if there was no
   link, the href was #.  This caused a page refresh and a blink
   of the tech radar.
3. Use xlink:href everywhere
   Previously, blips used xlink:href, but text still used href.
   xlink:href has actually been deprecated, but currently still
   has better cross-platform support.
4. Links can now open in new tabs
   Previously, links always opened in the existing tab.  This adds
   a new config: links_in_new_tabs.  Setting that to true will
   add a target="_blank" for all hrefs, causing the link to be
   opened in a new tab.  Setting config.links_in_new_tabs to false
   or not including it at all retains the old behavior.