### PR TITLE
Fix Kafka link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -537,7 +537,7 @@ radar_visualization({
         "quadrant": 3,
         "ring": 0,
         "label": "Kafka",
-        "link": "https://engineering.zalando.com/tags/kafka.html",
+        "link": "https://engineering.zalando.com/tags/apache-kafka.html",
         "active": true,
         "moved": 0
       },


### PR DESCRIPTION
Current link leads to error page instead of https://engineering.zalando.com/tags/apache-kafka.html