### PR TITLE
Enables links for blips. Makes link target configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ radar_visualization({
     { name: "OUTER",  color: "#f4c7c3" }
   ],
   print_layout: true,
+  links_in_new_tabs: true,
   entries: [
    {
       label: "Some Entry",

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,6 +39,7 @@ radar_visualization({
     { name: "HOLD", color: "#efafa9" }
   ],
   print_layout: true,
+  links_in_new_tabs: true,
   // zoomed_quadrant: 0,
   //ENTRIES
   entries: [

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -306,9 +306,8 @@ function radar_visualization(config) {
           .data(segmented[quadrant][ring])
           .enter()
             .append("a")
-              // Add an href if (and only if) there is a link
               .attr("href", function (d, i) {
-                 return d.link ? d.link : null;
+                 return d.link ? d.link : "#"; // stay on same page if no link was provided
               })
               // Add a target if (and only if) there is a link and we want new tabs
               .attr("target", function (d, i) {

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -306,9 +306,14 @@ function radar_visualization(config) {
           .data(segmented[quadrant][ring])
           .enter()
             .append("a")
-                .attr("href", function (d, i) {
-                  return d.link ? d.link : "#"; // stay on same page if no link was provided
-                })
+              // Add an href if (and only if) there is a link
+              .attr("href", function (d, i) {
+                 return d.link ? d.link : null;
+              })
+              // Add a target if (and only if) there is a link and we want new tabs
+              .attr("target", function (d, i) {
+                 return (d.link && config.links_in_new_tabs) ? "_blank" : null;
+              })
             .append("text")
               .attr("transform", function(d, i) { return legend_transform(quadrant, ring, i); })
               .attr("class", "legend" + quadrant + ring)
@@ -397,9 +402,13 @@ function radar_visualization(config) {
     var blip = d3.select(this);
 
     // blip link
-    if (!config.print_layout && d.active && d.hasOwnProperty("link")) {
+    if (d.active && d.hasOwnProperty("link") && d.link) {
       blip = blip.append("a")
         .attr("xlink:href", d.link);
+
+      if (config.links_in_new_tabs) {
+        blip.attr("target", "_blank");
+      }
     }
 
     // blip shape


### PR DESCRIPTION
Includes changes from #73.

1. Links are now always enabled for blips
   Previously, it was only enabled for blips if there is
   no legend (config.print_layout = true)
2. Use xlink:href everywhere
   Previously, blips used xlink:href, but text still used href.
   xlink:href has actually been deprecated, but currently still
   has better cross-platform support.
3. Links can now open in new tabs
   Previously, links always opened in the existing tab.  This adds
   a new config: links_in_new_tabs.  Setting that to true will
   add a target="_blank" for all hrefs, causing the link to be
   opened in a new tab.  Setting config.links_in_new_tabs to false
   or not including it at all retains the old behavior.