### PR TITLE
Adds more space in legend to avoid overlapping entries

### DIFF
--- a/docs/radar.js
+++ b/docs/radar.js
@@ -256,7 +256,7 @@ function radar_visualization(config) {
   }
 
   function legend_transform(quadrant, ring, index=null) {
-    var dx = ring < 2 ? 0 : 120;
+    var dx = ring < 2 ? 0 : 140;
     var dy = (index == null ? -16 : index * 12);
     if (ring % 2 === 1) {
       dy = dy + 36 + segmented[quadrant][ring-1].length * 12;


### PR DESCRIPTION
By increasing the margin between columns we can avoid overlapping text.

When one of the lengthier items moves to 1st column, most likely support for multi-line text will be required.

### Before
![Tech Radar with overlapping text](https://user-images.githubusercontent.com/711379/208981711-76293125-485f-4c87-9931-e1b6fc74fff2.png)

### After
![Tech Radar without overlapping text](https://user-images.githubusercontent.com/711379/208981729-e4f72ce1-a54d-4f80-be91-942798b73705.png)