### PR TITLE
fix: typo in docker technology url

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -351,7 +351,7 @@ radar_visualization({
         "quadrant": 1,
         "ring": 0,
         "label": "Docker",
-        "link": "https://engineering.zalando.com/tags/docker.html\"",
+        "link": "https://engineering.zalando.com/tags/docker.html",
         "active": true,
         "moved": 0
       },


### PR DESCRIPTION
Just a small typo fix for the Docker technology URL.