### PR TITLE
add: config.scale option

### DIFF
--- a/docs/radar.js
+++ b/docs/radar.js
@@ -191,6 +191,12 @@ function radar_visualization(config) {
     ].join(" ");
   }
 
+  { // adjust with config.scale.
+    config.scale = config.scale || 1;
+    config.width = config.width * config.scale;
+    config.height = config.height * config.scale;
+  }
+
   var svg = d3.select("svg#" + config.svg_id)
     .style("background-color", config.colors.background)
     .attr("width", config.width)
@@ -200,7 +206,7 @@ function radar_visualization(config) {
   if ("zoomed_quadrant" in config) {
     svg.attr("viewBox", viewbox(config.zoomed_quadrant));
   } else {
-    radar.attr("transform", translate(config.width / 2, config.height / 2));
+    radar.attr("transform", translate(config.width / 2, config.height / 2).concat(`scale(${config.scale})`));
   }
 
   var grid = radar.append("g");

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -191,22 +191,21 @@ function radar_visualization(config) {
     ].join(" ");
   }
 
-  { // adjust with config.scale.
-    config.scale = config.scale || 1;
-    config.width = config.width * config.scale;
-    config.height = config.height * config.scale;
-  }
+  // adjust with config.scale.
+  config.scale = config.scale || 1;
+  var scaled_width = config.width * config.scale;
+  var scaled_height = config.height * config.scale;
 
   var svg = d3.select("svg#" + config.svg_id)
     .style("background-color", config.colors.background)
-    .attr("width", config.width)
-    .attr("height", config.height);
+    .attr("width", scaled_width)
+    .attr("height", scaled_height);
 
   var radar = svg.append("g");
   if ("zoomed_quadrant" in config) {
     svg.attr("viewBox", viewbox(config.zoomed_quadrant));
   } else {
-    radar.attr("transform", translate(config.width / 2, config.height / 2).concat(`scale(${config.scale})`));
+    radar.attr("transform", translate(scaled_width / 2, scaled_height / 2).concat(`scale(${config.scale})`));
   }
 
   var grid = radar.append("g");


### PR DESCRIPTION
It will be good to support config.scale option for small size radar.
It produces 700/500 size radar from 1400/1000.

``` javascript
radar_visualization({
  svg_id: "radar",
  width: 1400,
  height: 1000,
  scale: 0.5,   ;; <<----
```
