### PR TITLE
Fix link to radar.js release

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Feel free to use and adapt it for your own purposes.
 
 ```html
 <script src="https://d3js.org/d3.v4.min.js"></script>
-<script src="http://zalando.github.io/tech-radar/release/radar-0.8.js"></script>
+<script src="https://zalando.github.io/tech-radar/release/radar-0.8.js"></script>
 ```
 
 2. insert an empty `svg` tag:


### PR DESCRIPTION
This should suggest the https link otherwise this fails in https-only environments like Github Pages.