### PR TITLE
Multiline legend items

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -3,561 +3,987 @@
   "entries": [
     {
       "quadrant": 3,
-      "ring": 1,
-      "label": "AWS Athena",
-      "active": true,
-      "moved": 1
-    },
-    {
-      "quadrant": 3,
       "ring": 0,
-      "label": "AWS EMR",
+      "label": "Appian",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://appian.com/"
     },
     {
-      "quadrant": 3,
+      "quadrant": 0,
+      "ring": 0,
+      "label": "Dash",
+      "active": true,
+      "moved": 0,
+      "link": "https://dash.plotly.com/"
+    },
+    {
+      "quadrant": 0,
       "ring": 2,
-      "label": "AWS Glue",
+      "label": "Deepchecks",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.deepchecks.com/"
     },
     {
-      "quadrant": 3,
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Docker",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.docker.com/"
+    },
+    {
+      "quadrant": 0,
       "ring": 2,
-      "label": "AWS Lake Formation",
+      "label": "Evidently",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.evidentlyai.com/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 1,
+      "label": "FastAPI",
+      "active": true,
+      "moved": 0,
+      "link": "https://fastapi.tiangolo.com/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 0,
+      "label": "Flask",
+      "active": true,
+      "moved": 0,
+      "link": "https://flask.palletsprojects.com/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 0,
+      "label": "Gunicorn",
+      "active": true,
+      "moved": 0,
+      "link": "https://gunicorn.org/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 0,
+      "label": "Java",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.java.com/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 0,
+      "label": "Keras",
+      "active": true,
+      "moved": 0,
+      "link": "https://keras.io/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 1,
+      "label": "OpenAI / ChatGPT",
+      "active": true,
+      "moved": 0,
+      "link": "https://chatgpt.com/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 0,
+      "label": "Python",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.python.org/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 1,
+      "label": "Pytorch",
+      "active": true,
+      "moved": 0,
+      "link": "https://pytorch.org/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 0,
+      "label": "Scikit-learn",
+      "active": true,
+      "moved": 0,
+      "link": "https://scikit-learn.org/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 0,
+      "label": "Tensorflow",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.tensorflow.org/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "AWS ECR",
+      "active": true,
+      "moved": 0,
+      "link": "https://aws.amazon.com/ecr/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Cloudflare",
+      "active": false,
+      "moved": 0,
+      "link": "https://www.cloudflare.com/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Cyberark",
+      "active": false,
+      "moved": 0,
+      "link": "https://www.cyberark.com/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Google composer",
+      "active": true,
+      "moved": 0,
+      "link": "https://cloud.google.com/composer"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Google Container Registry",
+      "active": true,
+      "moved": 0,
+      "link": "https://console.cloud.google.com/marketplace/product/google-cloud-platform/container-registry/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Google Dataproc",
+      "active": true,
+      "moved": 0,
+      "link": "https://cloud.google.com/dataproc"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Google PubSub",
+      "active": true,
+      "moved": 0,
+      "link": "https://cloud.google.com/pubsub"
     },
     {
       "quadrant": 3,
       "ring": 0,
-      "label": "Airflow",
+      "label": "Docker Desktop",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.docker.com/products/docker-desktop/"
     },
     {
       "quadrant": 3,
       "ring": 0,
-      "label": "Databricks",
+      "label": "Firebase Analytics",
       "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 3,
-      "ring": 1,
-      "label": "Flink",
-      "link": "https://engineering.zalando.com/tags/apache-flink.html",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 3,
-      "ring": 1,
-      "label": "Google BigQuery",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 3,
-      "ring": 1,
-      "label": "Presto",
-      "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://firebase.google.com/products/analytics"
     },
     {
       "quadrant": 3,
       "ring": 0,
-      "label": "Spark",
-      "link": "https://engineering.zalando.com/tags/apache-spark.html",
+      "label": "Sonar",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.sonarsource.com/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Auth0",
+      "active": true,
+      "moved": 0,
+      "link": "https://auth0.com/"
     },
     {
       "quadrant": 3,
-      "ring": 2,
-      "label": "Streamlit",
+      "ring": 0,
+      "label": "CodePush",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://microsoft.github.io/code-push/"
     },
     {
       "quadrant": 3,
-      "ring": 1,
-      "label": "dbt",
+      "ring": 3,
+      "label": "Graylog",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://graylog.org/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Jamf",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.jamf.com/"
     },
     {
       "quadrant": 2,
       "ring": 0,
-      "label": "AWS DynamoDB",
+      "label": "Kafka",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://kafka.apache.org/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Kubernetes",
+      "active": true,
+      "moved": 0,
+      "link": "https://kubernetes.io/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 1,
+      "label": "Prefect",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.prefect.io/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "PRTG",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.paessler.com/prtg"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "WorkspaceOne",
+      "active": true,
+      "moved": 0,
+      "link": "https://docs.vmware.com/en/VMware-Workspace-ONE/index.html"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Zoho",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.zoho.com/"
     },
     {
       "quadrant": 2,
       "ring": 0,
       "label": "AWS S3",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/s3/"
     },
     {
       "quadrant": 2,
       "ring": 0,
-      "label": "Amazon ElastiCache",
-      "link": "https://engineering.zalando.com/tags/redis.html",
+      "label": "MongoDB",
       "active": true,
-      "moved": 1
-    },
-    {
-      "quadrant": 2,
-      "ring": 2,
-      "label": "Amazon MemoryDB",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 1,
-      "label": "Amazon Redshift",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 1,
-      "label": "Amazon Feature Store",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 3,
-      "label": "Apache Cassandra",
-      "link": "https://engineering.zalando.com/tags/cassandra.html",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 3,
-      "label": "Consul",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 1,
-      "label": "Druid",
-      "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.mongodb.com/"
     },
     {
       "quadrant": 2,
       "ring": 0,
-      "label": "Elasticsearch",
-      "link": "https://engineering.zalando.com/tags/elasticsearch.html",
+      "label": "AWS RDS",
       "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "Exasol",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 3,
-      "label": "HBase",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 1,
-      "label": "HDFS",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 3,
-      "label": "Hazelcast",
-      "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/rds/"
     },
     {
       "quadrant": 2,
       "ring": 3,
       "label": "Memcached",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://memcached.org/"
     },
     {
       "quadrant": 2,
       "ring": 3,
-      "label": "MongoDB",
+      "label": "Hazelcast",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://hazelcast.com/"
     },
     {
       "quadrant": 2,
-      "ring": 3,
-      "label": "MySQL",
+      "ring": 1,
+      "label": "AppsFlyer",
       "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 3,
-      "label": "Oracle DB",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "PostgreSQL",
-      "link": "https://engineering.zalando.com/tags/postgresql.html",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 3,
-      "label": "Redis",
-      "link": "https://engineering.zalando.com/tags/redis.html",
-      "active": true,
-      "moved": -1
-    },
-    {
-      "quadrant": 2,
-      "ring": 2,
-      "label": "RocksDB",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 3,
-      "label": "Solr",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 2,
-      "ring": 2,
-      "label": "Valkey",
-      "link": "https://engineering.zalando.com/tags/redis.html",
-      "active": true,
-      "moved": 2
-    },
-    {
-      "quadrant": 2,
-      "ring": 3,
-      "label": "ZooKeeper",
-      "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.appsflyer.com/"
     },
     {
       "quadrant": 1,
-      "ring": 0,
-      "label": "AWS CloudFormation",
+      "ring": 2,
+      "label": "Service Mesh",
       "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "AWS CloudFront",
-      "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://kuma.io/"
     },
     {
       "quadrant": 1,
       "ring": 1,
-      "label": "AWS Elemental MediaConvert",
-      "active": true,
-      "moved": 0
+      "label": "ArgoCD",
+      "active": false,
+      "moved": 0,
+      "link": "https://argoproj.github.io/cd/"
     },
     {
       "quadrant": 1,
+      "ring": 0,
+      "label": "KrakenD",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.krakend.io/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Miro",
+      "active": true,
+      "moved": 0,
+      "link": "https://miro.com/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Harbor",
+      "active": true,
+      "moved": 0,
+      "link": "https://goharbor.io/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "HashiCorp Vault",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.hashicorp.com/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Helm",
+      "active": true,
+      "moved": 0,
+      "link": "https://helm.sh/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Terraform",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.terraform.io/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "KEDA",
+      "active": true,
+      "moved": 0,
+      "link": "https://keda.sh/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 3,
+      "label": "Ansible",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.ansible.com/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 3,
+      "label": "AWS ApiGateway",
+      "active": true,
+      "moved": 0,
+      "link": "https://aws.amazon.com/api-gateway/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 3,
+      "label": "Kong",
+      "active": true,
+      "moved": 0,
+      "link": "https://konghq.com/products/kong-gateway"
+    },
+    {
+      "quadrant": 1,
+      "ring": 3,
+      "label": "Hewlett Packard Enterprise",
+      "active": false,
+      "moved": 0,
+      "link": "https://www.hpe.com/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 3,
+      "label": "Spinnaker",
+      "active": true,
+      "moved": 0,
+      "link": "https://spinnaker.io/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 3,
+      "label": "VMware",
+      "active": false,
+      "moved": 0,
+      "link": "https://www.vmware.com/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 3,
+      "label": "Pure Storage",
+      "active": false,
+      "moved": 0,
+      "link": "https://www.purestorage.com/"
+    },
+    {
+      "quadrant": 2,
       "ring": 1,
+      "label": "Apache Iceberg",
+      "active": true,
+      "moved": 0,
+      "link": "https://iceberg.apache.org/"
+    },
+    {
+      "quadrant": 1,
+      "ring": 2,
       "label": "AWS Lambda",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/lambda/"
     },
     {
-      "quadrant": 1,
-      "ring": 2,
-      "label": "AWS Service Catalog",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 1,
+      "quadrant": 2,
       "ring": 1,
-      "label": "AWS Step Functions",
+      "label": "Clickhouse",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://clickhouse.com/"
     },
     {
-      "quadrant": 1,
-      "ring": 2,
-      "label": "Amazon Bedrock",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 1,
-      "ring": 2,
-      "label": "Amazon Pinpoint",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Amazon SageMaker",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Docker",
-      "link": "https://engineering.zalando.com/tags/docker.html",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 1,
-      "ring": 2,
-      "label": "GraalVM",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 1,
-      "ring": 2,
-      "label": "Kotlin Multiplatform",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Kubernetes",
-      "link": "https://engineering.zalando.com/tags/kubernetes.html",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 1,
+      "quadrant": 2,
       "ring": 1,
-      "label": "Open Policy Agent",
+      "label": "Elasticsearch",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.elastic.co/elasticsearch"
     },
     {
-      "quadrant": 1,
+      "quadrant": 2,
+      "ring": 1,
+      "label": "OpenSearch",
+      "active": true,
+      "moved": 0,
+      "link": "https://opensearch.org/"
+    },
+    {
+      "quadrant": 2,
       "ring": 0,
+      "label": "SQLite",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.sqlite.org/"
+    },
+    {
+      "quadrant": 2,
+      "ring": 2,
+      "label": "AWS Aurora",
+      "active": true,
+      "moved": 0,
+      "link": "https://aws.amazon.com/rds/aurora/"
+    },
+    {
+      "quadrant": 2,
+      "ring": 2,
+      "label": "AWS DynamoDB",
+      "active": true,
+      "moved": 0,
+      "link": "https://aws.amazon.com/dynamodb/"
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "RabbitMQ",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.rabbitmq.com/"
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "Google BigQuery",
+      "active": true,
+      "moved": 0,
+      "link": "https://cloud.google.com/bigquery"
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "Bigtable",
+      "active": true,
+      "moved": 0,
+      "link": "https://cloud.google.com/bigtable"
+    },
+    {
+      "quadrant": 2,
+      "ring": 3,
+      "label": "DocumentDB",
+      "active": true,
+      "moved": 0,
+      "link": "https://aws.amazon.com/documentdb/"
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "Exavault",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.exavault.com/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Gitlab",
+      "active": true,
+      "moved": 0,
+      "link": "https://about.gitlab.com/"
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "Google Cloud Storage",
+      "active": true,
+      "moved": 0,
+      "link": "https://cloud.google.com/storage/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Grafana",
+      "active": true,
+      "moved": 0,
+      "link": "https://grafana.com/"
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "Polar",
+      "active": true,
+      "moved": 0,
+      "link": "https://realpython.com/polars-python/"
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "Postgres",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.postgresql.org/"
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "Redis",
+      "active": true,
+      "moved": 0,
+      "link": "https://redis.io/"
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "Spark",
+      "active": true,
+      "moved": 0,
+      "link": "https://spark.apache.org/"
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "Spotfire",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.spotfire.com//"
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "Talend",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.talend.com/"
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "Vertica",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.vertica.com/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Abstract Studio Design",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.abstract.com/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Adobe Systems Software",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.adobe.com/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Autocad",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.autodesk.com/products/autocad/overview"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Cloudinary",
+      "active": true,
+      "moved": 0,
+      "link": "https://cloudinary.com/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Dynamics Business Central",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.microsoft.com/en-us/dynamics-365/products/business-central/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Figma Software",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.figma.com/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Google Tag Manager (GTM)",
+      "active": false,
+      "moved": 0,
+      "link": "https://tagmanager.google.com/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Hotjar",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.hotjar.com/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 3,
+      "label": "Maven",
+      "active": true,
+      "moved": 0,
+      "link": "https://maven.apache.org/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Prometheus",
+      "active": true,
+      "moved": 0,
+      "link": "https://prometheus.io/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 1,
       "label": "OpenTelemetry",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://opentelemetry.io/"
     },
     {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Skipper",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 1,
-      "ring": 2,
-      "label": "Slurm",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 1,
+      "quadrant": 3,
       "ring": 1,
-      "label": "WebAssembly",
+      "label": "Rancher Desktop",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://rancherdesktop.io/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 1,
+      "label": "Stackdriver",
+      "active": false,
+      "moved": 0,
+      "link": "https://cloud.google.com/products/operations"
+    },
+    {
+      "quadrant": 3,
+      "ring": 2,
+      "label": "Copilot",
+      "active": true,
+      "moved": 0,
+      "link": "https://copilot.microsoft.com/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 2,
+      "label": "Cursor",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.cursor.com/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 2,
+      "label": "Sentry",
+      "active": true,
+      "moved": 0,
+      "link": "https://sentry.io/"
+    },
+    {
+      "quadrant": 3,
+      "ring": 2,
+      "label": "Lighthouse",
+      "active": true,
+      "moved": 0,
+      "link": "https://github.com/GoogleChrome/lighthouse"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Rapidi",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.rapidionline.com/resources/tag/salesforce-integration"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Think Cell",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.think-cell.com/"
     },
     {
       "quadrant": 1,
       "ring": 0,
-      "label": "ZMON",
+      "label": "VMware Fusion",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.vmware.com/info/fusion/faq"
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "VTENext",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.vtenext.com/"
     },
     {
       "quadrant": 0,
       "ring": 3,
-      "label": "Clojure",
-      "link": "https://engineering.zalando.com/tags/clojure.html",
+      "label": "Backbone.js",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://backbonejs.org/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 3,
+      "label": "C++",
+      "active": true,
+      "moved": 0,
+      "link": "https://isocpp.org/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 3,
+      "label": "Struts",
+      "active": true,
+      "moved": 0,
+      "link": "https://struts.apache.org/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 2,
+      "label": "Vaadin",
+      "active": true,
+      "moved": 0,
+      "link": "https://vaadin.com/"
     },
     {
       "quadrant": 0,
       "ring": 1,
-      "label": "Dart",
+      "label": "PHP",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.php.net/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 1,
+      "label": "Axon Framework",
+      "active": true,
+      "moved": 0,
+      "link": "https://www.axoniq.io/products/axon-framework"
+    },
+    {
+      "quadrant": 0,
+      "ring": 1,
+      "label": "Module Federation (Micro FE)",
+      "active": true,
+      "moved": 0,
+      "link": "https://webpack.js.org/concepts/module-federation/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 0,
+      "label": ".NET",
+      "active": true,
+      "moved": 0,
+      "link": "https://dotnet.microsoft.com/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 0,
+      "label": "C#",
+      "active": true,
+      "moved": 0,
+      "link": "https://learn.microsoft.com/en-gb/dotnet/csharp/"
     },
     {
       "quadrant": 0,
       "ring": 0,
       "label": "Go",
-      "link": "https://engineering.zalando.com/tags/golang.html",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://go.dev/"
     },
     {
       "quadrant": 0,
       "ring": 0,
       "label": "GraphQL",
-      "link": "https://engineering.zalando.com/tags/graphql.html",
       "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 0,
-      "ring": 3,
-      "label": "Haskell",
-      "link": "https://engineering.zalando.com/tags/haskell.html",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 0,
-      "ring": 0,
-      "label": "Java",
-      "link": "https://engineering.zalando.com/tags/java.html",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 0,
-      "ring": 0,
-      "label": "JavaScript",
-      "link": "https://engineering.zalando.com/tags/javascript.html",
-      "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://graphql.org/"
     },
     {
       "quadrant": 0,
       "ring": 0,
       "label": "Kotlin",
-      "link": "https://engineering.zalando.com/tags/kotlin.html",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://kotlinlang.org/"
     },
     {
       "quadrant": 0,
       "ring": 0,
-      "label": "OpenAPI (Swagger)",
-      "link": "https://engineering.zalando.com/tags/openapi.html",
+      "label": "Next.js",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://nextjs.org/"
     },
     {
       "quadrant": 0,
       "ring": 0,
-      "label": "Python",
-      "link": "https://engineering.zalando.com/tags/python.html",
+      "label": "Node.js",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://nodejs.org/"
     },
     {
       "quadrant": 0,
-      "ring": 2,
-      "label": "R",
+      "ring": 0,
+      "label": "PrimeFaces",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.primefaces.org/"
     },
     {
       "quadrant": 0,
-      "ring": 3,
-      "label": "Rust",
-      "link": "https://engineering.zalando.com/tags/rust.html",
+      "ring": 0,
+      "label": "React JS",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://react.dev/"
+    },
+    {
+      "quadrant": 0,
+      "ring": 0,
+      "label": "React Native",
+      "active": true,
+      "moved": 0,
+      "link": "https://reactnative.dev/"
     },
     {
       "quadrant": 0,
       "ring": 0,
       "label": "Scala",
-      "link": "https://engineering.zalando.com/tags/scala.html",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.scala-lang.org/"
     },
     {
       "quadrant": 0,
       "ring": 0,
-      "label": "Swift",
-      "link": "https://engineering.zalando.com/tags/swift.html",
+      "label": "SpringBoot",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://spring.io/projects/spring-boot"
+    },
+    {
+      "quadrant": 0,
+      "ring": 0,
+      "label": "SwiftUI",
+      "active": true,
+      "moved": 0,
+      "link": "https://developer.apple.com/xcode/swiftui/"
     },
     {
       "quadrant": 0,
       "ring": 0,
       "label": "TypeScript",
-      "link": "https://engineering.zalando.com/tags/typescript.html",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.typescriptlang.org/"
     },
     {
       "quadrant": 3,
       "ring": 0,
-      "label": "AWS Kinesis",
+      "label": "Zuora",
       "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "AWS SNS",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "AWS SQS",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Kafka",
-      "link": "https://engineering.zalando.com/tags/apache-kafka.html",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Nakadi",
-      "link": "https://nakadi.io",
-      "active": true,
-      "moved": 0
-    },
-    {
-      "quadrant": 3,
-      "ring": 1,
-      "label": "RabbitMQ",
-      "link": "https://engineering.zalando.com/tags/rabbitmq.html",
-      "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.zuora.com/"
     }
   ]
 }

--- a/docs/config.json
+++ b/docs/config.json
@@ -3,987 +3,561 @@
   "entries": [
     {
       "quadrant": 3,
-      "ring": 0,
-      "label": "Appian",
+      "ring": 1,
+      "label": "AWS Athena",
       "active": true,
-      "moved": 0,
-      "link": "https://appian.com/"
+      "moved": 1
     },
     {
-      "quadrant": 0,
+      "quadrant": 3,
       "ring": 0,
-      "label": "Dash",
+      "label": "AWS EMR",
       "active": true,
-      "moved": 0,
-      "link": "https://dash.plotly.com/"
+      "moved": 0
     },
     {
-      "quadrant": 0,
+      "quadrant": 3,
       "ring": 2,
-      "label": "Deepchecks",
+      "label": "AWS Glue",
       "active": true,
-      "moved": 0,
-      "link": "https://www.deepchecks.com/"
+      "moved": 0
     },
     {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Docker",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.docker.com/"
-    },
-    {
-      "quadrant": 0,
+      "quadrant": 3,
       "ring": 2,
-      "label": "Evidently",
+      "label": "AWS Lake Formation",
       "active": true,
-      "moved": 0,
-      "link": "https://www.evidentlyai.com/"
+      "moved": 0
     },
     {
-      "quadrant": 0,
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Airflow",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Databricks",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 3,
       "ring": 1,
-      "label": "FastAPI",
+      "label": "Flink",
+      "link": "https://engineering.zalando.com/tags/apache-flink.html",
       "active": true,
-      "moved": 0,
-      "link": "https://fastapi.tiangolo.com/"
+      "moved": 0
     },
     {
-      "quadrant": 0,
-      "ring": 0,
-      "label": "Flask",
-      "active": true,
-      "moved": 0,
-      "link": "https://flask.palletsprojects.com/"
-    },
-    {
-      "quadrant": 0,
-      "ring": 0,
-      "label": "Gunicorn",
-      "active": true,
-      "moved": 0,
-      "link": "https://gunicorn.org/"
-    },
-    {
-      "quadrant": 0,
-      "ring": 0,
-      "label": "Java",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.java.com/"
-    },
-    {
-      "quadrant": 0,
-      "ring": 0,
-      "label": "Keras",
-      "active": true,
-      "moved": 0,
-      "link": "https://keras.io/"
-    },
-    {
-      "quadrant": 0,
+      "quadrant": 3,
       "ring": 1,
-      "label": "OpenAI / ChatGPT",
+      "label": "Google BigQuery",
       "active": true,
-      "moved": 0,
-      "link": "https://chatgpt.com/"
+      "moved": 0
     },
     {
-      "quadrant": 0,
-      "ring": 0,
-      "label": "Python",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.python.org/"
-    },
-    {
-      "quadrant": 0,
+      "quadrant": 3,
       "ring": 1,
-      "label": "Pytorch",
+      "label": "Presto",
       "active": true,
-      "moved": 0,
-      "link": "https://pytorch.org/"
-    },
-    {
-      "quadrant": 0,
-      "ring": 0,
-      "label": "Scikit-learn",
-      "active": true,
-      "moved": 0,
-      "link": "https://scikit-learn.org/"
-    },
-    {
-      "quadrant": 0,
-      "ring": 0,
-      "label": "Tensorflow",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.tensorflow.org/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "AWS ECR",
-      "active": true,
-      "moved": 0,
-      "link": "https://aws.amazon.com/ecr/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Cloudflare",
-      "active": false,
-      "moved": 0,
-      "link": "https://www.cloudflare.com/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Cyberark",
-      "active": false,
-      "moved": 0,
-      "link": "https://www.cyberark.com/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Google composer",
-      "active": true,
-      "moved": 0,
-      "link": "https://cloud.google.com/composer"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Google Container Registry",
-      "active": true,
-      "moved": 0,
-      "link": "https://console.cloud.google.com/marketplace/product/google-cloud-platform/container-registry/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Google Dataproc",
-      "active": true,
-      "moved": 0,
-      "link": "https://cloud.google.com/dataproc"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Google PubSub",
-      "active": true,
-      "moved": 0,
-      "link": "https://cloud.google.com/pubsub"
+      "moved": 0
     },
     {
       "quadrant": 3,
       "ring": 0,
-      "label": "Docker Desktop",
+      "label": "Spark",
+      "link": "https://engineering.zalando.com/tags/apache-spark.html",
       "active": true,
-      "moved": 0,
-      "link": "https://www.docker.com/products/docker-desktop/"
+      "moved": 0
     },
     {
       "quadrant": 3,
-      "ring": 0,
-      "label": "Firebase Analytics",
+      "ring": 2,
+      "label": "Streamlit",
       "active": true,
-      "moved": 0,
-      "link": "https://firebase.google.com/products/analytics"
+      "moved": 0
     },
     {
       "quadrant": 3,
-      "ring": 0,
-      "label": "Sonar",
+      "ring": 1,
+      "label": "dbt",
       "active": true,
-      "moved": 0,
-      "link": "https://www.sonarsource.com/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Auth0",
-      "active": true,
-      "moved": 0,
-      "link": "https://auth0.com/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "CodePush",
-      "active": true,
-      "moved": 0,
-      "link": "https://microsoft.github.io/code-push/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 3,
-      "label": "Graylog",
-      "active": true,
-      "moved": 0,
-      "link": "https://graylog.org/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Jamf",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.jamf.com/"
+      "moved": 0
     },
     {
       "quadrant": 2,
       "ring": 0,
-      "label": "Kafka",
+      "label": "AWS DynamoDB",
       "active": true,
-      "moved": 0,
-      "link": "https://kafka.apache.org/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Kubernetes",
-      "active": true,
-      "moved": 0,
-      "link": "https://kubernetes.io/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 1,
-      "label": "Prefect",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.prefect.io/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "PRTG",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.paessler.com/prtg"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "WorkspaceOne",
-      "active": true,
-      "moved": 0,
-      "link": "https://docs.vmware.com/en/VMware-Workspace-ONE/index.html"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Zoho",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.zoho.com/"
+      "moved": 0
     },
     {
       "quadrant": 2,
       "ring": 0,
       "label": "AWS S3",
       "active": true,
-      "moved": 0,
-      "link": "https://aws.amazon.com/s3/"
+      "moved": 0
     },
     {
       "quadrant": 2,
       "ring": 0,
-      "label": "MongoDB",
+      "label": "Amazon ElastiCache",
+      "link": "https://engineering.zalando.com/tags/redis.html",
       "active": true,
-      "moved": 0,
-      "link": "https://www.mongodb.com/"
+      "moved": 1
     },
     {
       "quadrant": 2,
-      "ring": 0,
-      "label": "AWS RDS",
+      "ring": 2,
+      "label": "Amazon MemoryDB",
       "active": true,
-      "moved": 0,
-      "link": "https://aws.amazon.com/rds/"
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 1,
+      "label": "Amazon Redshift",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 1,
+      "label": "Amazon Feature Store",
+      "active": true,
+      "moved": 0
     },
     {
       "quadrant": 2,
       "ring": 3,
-      "label": "Memcached",
+      "label": "Apache Cassandra",
+      "link": "https://engineering.zalando.com/tags/cassandra.html",
       "active": true,
-      "moved": 0,
-      "link": "https://memcached.org/"
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 3,
+      "label": "Consul",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 1,
+      "label": "Druid",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "Elasticsearch",
+      "link": "https://engineering.zalando.com/tags/elasticsearch.html",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "Exasol",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 3,
+      "label": "HBase",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 1,
+      "label": "HDFS",
+      "active": true,
+      "moved": 0
     },
     {
       "quadrant": 2,
       "ring": 3,
       "label": "Hazelcast",
       "active": true,
-      "moved": 0,
-      "link": "https://hazelcast.com/"
+      "moved": 0
     },
     {
       "quadrant": 2,
-      "ring": 1,
-      "label": "AppsFlyer",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.appsflyer.com/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 2,
-      "label": "Service Mesh",
-      "active": true,
-      "moved": 0,
-      "link": "https://kuma.io/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 1,
-      "label": "ArgoCD",
-      "active": false,
-      "moved": 0,
-      "link": "https://argoproj.github.io/cd/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "KrakenD",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.krakend.io/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Miro",
-      "active": true,
-      "moved": 0,
-      "link": "https://miro.com/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Harbor",
-      "active": true,
-      "moved": 0,
-      "link": "https://goharbor.io/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "HashiCorp Vault",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.hashicorp.com/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Helm",
-      "active": true,
-      "moved": 0,
-      "link": "https://helm.sh/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "Terraform",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.terraform.io/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 0,
-      "label": "KEDA",
-      "active": true,
-      "moved": 0,
-      "link": "https://keda.sh/"
-    },
-    {
-      "quadrant": 1,
       "ring": 3,
-      "label": "Ansible",
+      "label": "Memcached",
       "active": true,
-      "moved": 0,
-      "link": "https://www.ansible.com/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 3,
-      "label": "AWS ApiGateway",
-      "active": true,
-      "moved": 0,
-      "link": "https://aws.amazon.com/api-gateway/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 3,
-      "label": "Kong",
-      "active": true,
-      "moved": 0,
-      "link": "https://konghq.com/products/kong-gateway"
-    },
-    {
-      "quadrant": 1,
-      "ring": 3,
-      "label": "Hewlett Packard Enterprise",
-      "active": false,
-      "moved": 0,
-      "link": "https://www.hpe.com/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 3,
-      "label": "Spinnaker",
-      "active": true,
-      "moved": 0,
-      "link": "https://spinnaker.io/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 3,
-      "label": "VMware",
-      "active": false,
-      "moved": 0,
-      "link": "https://www.vmware.com/"
-    },
-    {
-      "quadrant": 1,
-      "ring": 3,
-      "label": "Pure Storage",
-      "active": false,
-      "moved": 0,
-      "link": "https://www.purestorage.com/"
+      "moved": 0
     },
     {
       "quadrant": 2,
-      "ring": 1,
-      "label": "Apache Iceberg",
+      "ring": 3,
+      "label": "MongoDB",
       "active": true,
-      "moved": 0,
-      "link": "https://iceberg.apache.org/"
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 3,
+      "label": "MySQL",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 3,
+      "label": "Oracle DB",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "PostgreSQL",
+      "link": "https://engineering.zalando.com/tags/postgresql.html",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 3,
+      "label": "Redis",
+      "link": "https://engineering.zalando.com/tags/redis.html",
+      "active": true,
+      "moved": -1
+    },
+    {
+      "quadrant": 2,
+      "ring": 2,
+      "label": "RocksDB",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 3,
+      "label": "Solr",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 2,
+      "ring": 2,
+      "label": "Valkey",
+      "link": "https://engineering.zalando.com/tags/redis.html",
+      "active": true,
+      "moved": 2
+    },
+    {
+      "quadrant": 2,
+      "ring": 3,
+      "label": "ZooKeeper",
+      "active": true,
+      "moved": 0
     },
     {
       "quadrant": 1,
-      "ring": 2,
+      "ring": 0,
+      "label": "AWS CloudFormation",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "AWS CloudFront",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 1,
+      "ring": 1,
+      "label": "AWS Elemental MediaConvert",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 1,
+      "ring": 1,
       "label": "AWS Lambda",
       "active": true,
-      "moved": 0,
-      "link": "https://aws.amazon.com/lambda/"
+      "moved": 0
     },
     {
-      "quadrant": 2,
-      "ring": 1,
-      "label": "Clickhouse",
-      "active": true,
-      "moved": 0,
-      "link": "https://clickhouse.com/"
-    },
-    {
-      "quadrant": 2,
-      "ring": 1,
-      "label": "Elasticsearch",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.elastic.co/elasticsearch"
-    },
-    {
-      "quadrant": 2,
-      "ring": 1,
-      "label": "OpenSearch",
-      "active": true,
-      "moved": 0,
-      "link": "https://opensearch.org/"
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "SQLite",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.sqlite.org/"
-    },
-    {
-      "quadrant": 2,
+      "quadrant": 1,
       "ring": 2,
-      "label": "AWS Aurora",
+      "label": "AWS Service Catalog",
       "active": true,
-      "moved": 0,
-      "link": "https://aws.amazon.com/rds/aurora/"
+      "moved": 0
     },
     {
-      "quadrant": 2,
-      "ring": 2,
-      "label": "AWS DynamoDB",
-      "active": true,
-      "moved": 0,
-      "link": "https://aws.amazon.com/dynamodb/"
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "RabbitMQ",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.rabbitmq.com/"
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "Google BigQuery",
-      "active": true,
-      "moved": 0,
-      "link": "https://cloud.google.com/bigquery"
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "Bigtable",
-      "active": true,
-      "moved": 0,
-      "link": "https://cloud.google.com/bigtable"
-    },
-    {
-      "quadrant": 2,
-      "ring": 3,
-      "label": "DocumentDB",
-      "active": true,
-      "moved": 0,
-      "link": "https://aws.amazon.com/documentdb/"
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "Exavault",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.exavault.com/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Gitlab",
-      "active": true,
-      "moved": 0,
-      "link": "https://about.gitlab.com/"
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "Google Cloud Storage",
-      "active": true,
-      "moved": 0,
-      "link": "https://cloud.google.com/storage/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Grafana",
-      "active": true,
-      "moved": 0,
-      "link": "https://grafana.com/"
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "Polar",
-      "active": true,
-      "moved": 0,
-      "link": "https://realpython.com/polars-python/"
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "Postgres",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.postgresql.org/"
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "Redis",
-      "active": true,
-      "moved": 0,
-      "link": "https://redis.io/"
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "Spark",
-      "active": true,
-      "moved": 0,
-      "link": "https://spark.apache.org/"
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "Spotfire",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.spotfire.com//"
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "Talend",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.talend.com/"
-    },
-    {
-      "quadrant": 2,
-      "ring": 0,
-      "label": "Vertica",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.vertica.com/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Abstract Studio Design",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.abstract.com/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Adobe Systems Software",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.adobe.com/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Autocad",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.autodesk.com/products/autocad/overview"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Cloudinary",
-      "active": true,
-      "moved": 0,
-      "link": "https://cloudinary.com/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Dynamics Business Central",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.microsoft.com/en-us/dynamics-365/products/business-central/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Figma Software",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.figma.com/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Google Tag Manager (GTM)",
-      "active": false,
-      "moved": 0,
-      "link": "https://tagmanager.google.com/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Hotjar",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.hotjar.com/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 3,
-      "label": "Maven",
-      "active": true,
-      "moved": 0,
-      "link": "https://maven.apache.org/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Prometheus",
-      "active": true,
-      "moved": 0,
-      "link": "https://prometheus.io/"
-    },
-    {
-      "quadrant": 3,
+      "quadrant": 1,
       "ring": 1,
-      "label": "OpenTelemetry",
+      "label": "AWS Step Functions",
       "active": true,
-      "moved": 0,
-      "link": "https://opentelemetry.io/"
+      "moved": 0
     },
     {
-      "quadrant": 3,
-      "ring": 1,
-      "label": "Rancher Desktop",
-      "active": true,
-      "moved": 0,
-      "link": "https://rancherdesktop.io/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 1,
-      "label": "Stackdriver",
-      "active": false,
-      "moved": 0,
-      "link": "https://cloud.google.com/products/operations"
-    },
-    {
-      "quadrant": 3,
+      "quadrant": 1,
       "ring": 2,
-      "label": "Copilot",
+      "label": "Amazon Bedrock",
       "active": true,
-      "moved": 0,
-      "link": "https://copilot.microsoft.com/"
+      "moved": 0
     },
     {
-      "quadrant": 3,
+      "quadrant": 1,
       "ring": 2,
-      "label": "Cursor",
+      "label": "Amazon Pinpoint",
       "active": true,
-      "moved": 0,
-      "link": "https://www.cursor.com/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 2,
-      "label": "Sentry",
-      "active": true,
-      "moved": 0,
-      "link": "https://sentry.io/"
-    },
-    {
-      "quadrant": 3,
-      "ring": 2,
-      "label": "Lighthouse",
-      "active": true,
-      "moved": 0,
-      "link": "https://github.com/GoogleChrome/lighthouse"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Rapidi",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.rapidionline.com/resources/tag/salesforce-integration"
-    },
-    {
-      "quadrant": 3,
-      "ring": 0,
-      "label": "Think Cell",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.think-cell.com/"
+      "moved": 0
     },
     {
       "quadrant": 1,
       "ring": 0,
-      "label": "VMware Fusion",
+      "label": "Amazon SageMaker",
       "active": true,
-      "moved": 0,
-      "link": "https://www.vmware.com/info/fusion/faq"
+      "moved": 0
     },
     {
-      "quadrant": 3,
+      "quadrant": 1,
       "ring": 0,
-      "label": "VTENext",
+      "label": "Docker",
+      "link": "https://engineering.zalando.com/tags/docker.html",
       "active": true,
-      "moved": 0,
-      "link": "https://www.vtenext.com/"
+      "moved": 0
     },
     {
-      "quadrant": 0,
-      "ring": 3,
-      "label": "Backbone.js",
-      "active": true,
-      "moved": 0,
-      "link": "https://backbonejs.org/"
-    },
-    {
-      "quadrant": 0,
-      "ring": 3,
-      "label": "C++",
-      "active": true,
-      "moved": 0,
-      "link": "https://isocpp.org/"
-    },
-    {
-      "quadrant": 0,
-      "ring": 3,
-      "label": "Struts",
-      "active": true,
-      "moved": 0,
-      "link": "https://struts.apache.org/"
-    },
-    {
-      "quadrant": 0,
+      "quadrant": 1,
       "ring": 2,
-      "label": "Vaadin",
+      "label": "GraalVM",
       "active": true,
-      "moved": 0,
-      "link": "https://vaadin.com/"
+      "moved": 0
     },
     {
-      "quadrant": 0,
-      "ring": 1,
-      "label": "PHP",
+      "quadrant": 1,
+      "ring": 2,
+      "label": "Kotlin Multiplatform",
       "active": true,
-      "moved": 0,
-      "link": "https://www.php.net/"
+      "moved": 0
     },
     {
-      "quadrant": 0,
-      "ring": 1,
-      "label": "Axon Framework",
-      "active": true,
-      "moved": 0,
-      "link": "https://www.axoniq.io/products/axon-framework"
-    },
-    {
-      "quadrant": 0,
-      "ring": 1,
-      "label": "Module Federation (Micro FE)",
-      "active": true,
-      "moved": 0,
-      "link": "https://webpack.js.org/concepts/module-federation/"
-    },
-    {
-      "quadrant": 0,
+      "quadrant": 1,
       "ring": 0,
-      "label": ".NET",
+      "label": "Kubernetes",
+      "link": "https://engineering.zalando.com/tags/kubernetes.html",
       "active": true,
-      "moved": 0,
-      "link": "https://dotnet.microsoft.com/"
+      "moved": 0
+    },
+    {
+      "quadrant": 1,
+      "ring": 1,
+      "label": "Open Policy Agent",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "OpenTelemetry",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "Skipper",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 1,
+      "ring": 2,
+      "label": "Slurm",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 1,
+      "ring": 1,
+      "label": "WebAssembly",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 1,
+      "ring": 0,
+      "label": "ZMON",
+      "active": true,
+      "moved": 0
     },
     {
       "quadrant": 0,
-      "ring": 0,
-      "label": "C#",
+      "ring": 3,
+      "label": "Clojure",
+      "link": "https://engineering.zalando.com/tags/clojure.html",
       "active": true,
-      "moved": 0,
-      "link": "https://learn.microsoft.com/en-gb/dotnet/csharp/"
+      "moved": 0
+    },
+    {
+      "quadrant": 0,
+      "ring": 1,
+      "label": "Dart",
+      "active": true,
+      "moved": 0
     },
     {
       "quadrant": 0,
       "ring": 0,
       "label": "Go",
+      "link": "https://engineering.zalando.com/tags/golang.html",
       "active": true,
-      "moved": 0,
-      "link": "https://go.dev/"
+      "moved": 0
     },
     {
       "quadrant": 0,
       "ring": 0,
       "label": "GraphQL",
+      "link": "https://engineering.zalando.com/tags/graphql.html",
       "active": true,
-      "moved": 0,
-      "link": "https://graphql.org/"
+      "moved": 0
+    },
+    {
+      "quadrant": 0,
+      "ring": 3,
+      "label": "Haskell",
+      "link": "https://engineering.zalando.com/tags/haskell.html",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 0,
+      "ring": 0,
+      "label": "Java",
+      "link": "https://engineering.zalando.com/tags/java.html",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 0,
+      "ring": 0,
+      "label": "JavaScript",
+      "link": "https://engineering.zalando.com/tags/javascript.html",
+      "active": true,
+      "moved": 0
     },
     {
       "quadrant": 0,
       "ring": 0,
       "label": "Kotlin",
+      "link": "https://engineering.zalando.com/tags/kotlin.html",
       "active": true,
-      "moved": 0,
-      "link": "https://kotlinlang.org/"
+      "moved": 0
     },
     {
       "quadrant": 0,
       "ring": 0,
-      "label": "Next.js",
+      "label": "OpenAPI (Swagger)",
+      "link": "https://engineering.zalando.com/tags/openapi.html",
       "active": true,
-      "moved": 0,
-      "link": "https://nextjs.org/"
+      "moved": 0
     },
     {
       "quadrant": 0,
       "ring": 0,
-      "label": "Node.js",
+      "label": "Python",
+      "link": "https://engineering.zalando.com/tags/python.html",
       "active": true,
-      "moved": 0,
-      "link": "https://nodejs.org/"
+      "moved": 0
     },
     {
       "quadrant": 0,
-      "ring": 0,
-      "label": "PrimeFaces",
+      "ring": 2,
+      "label": "R",
       "active": true,
-      "moved": 0,
-      "link": "https://www.primefaces.org/"
+      "moved": 0
     },
     {
       "quadrant": 0,
-      "ring": 0,
-      "label": "React JS",
+      "ring": 3,
+      "label": "Rust",
+      "link": "https://engineering.zalando.com/tags/rust.html",
       "active": true,
-      "moved": 0,
-      "link": "https://react.dev/"
-    },
-    {
-      "quadrant": 0,
-      "ring": 0,
-      "label": "React Native",
-      "active": true,
-      "moved": 0,
-      "link": "https://reactnative.dev/"
+      "moved": 0
     },
     {
       "quadrant": 0,
       "ring": 0,
       "label": "Scala",
+      "link": "https://engineering.zalando.com/tags/scala.html",
       "active": true,
-      "moved": 0,
-      "link": "https://www.scala-lang.org/"
+      "moved": 0
     },
     {
       "quadrant": 0,
       "ring": 0,
-      "label": "SpringBoot",
+      "label": "Swift",
+      "link": "https://engineering.zalando.com/tags/swift.html",
       "active": true,
-      "moved": 0,
-      "link": "https://spring.io/projects/spring-boot"
-    },
-    {
-      "quadrant": 0,
-      "ring": 0,
-      "label": "SwiftUI",
-      "active": true,
-      "moved": 0,
-      "link": "https://developer.apple.com/xcode/swiftui/"
+      "moved": 0
     },
     {
       "quadrant": 0,
       "ring": 0,
       "label": "TypeScript",
+      "link": "https://engineering.zalando.com/tags/typescript.html",
       "active": true,
-      "moved": 0,
-      "link": "https://www.typescriptlang.org/"
+      "moved": 0
     },
     {
       "quadrant": 3,
       "ring": 0,
-      "label": "Zuora",
+      "label": "AWS Kinesis",
       "active": true,
-      "moved": 0,
-      "link": "https://www.zuora.com/"
+      "moved": 0
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "AWS SNS",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "AWS SQS",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Kafka",
+      "link": "https://engineering.zalando.com/tags/apache-kafka.html",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 3,
+      "ring": 0,
+      "label": "Nakadi",
+      "link": "https://nakadi.io",
+      "active": true,
+      "moved": 0
+    },
+    {
+      "quadrant": 3,
+      "ring": 1,
+      "label": "RabbitMQ",
+      "link": "https://engineering.zalando.com/tags/rabbitmq.html",
+      "active": true,
+      "moved": 0
     }
   ]
 }

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -395,7 +395,7 @@ function radar_visualization(config) {
         line.push(words[position]);
         tspan.text(line.join(" "));
 
-        // Avoid wrap for first line to end up in a situation where the long text without whitespace is wrapped
+        // Avoid wrap for first line (position !== 1) to end up in a situation where the long text without whitespace is wrapped
         // (causing the first line near the legend number to be blank).
         if (tspan.node().getComputedTextLength() > config.legend_column_width && position !== 1) {
           line.pop();

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -274,7 +274,7 @@ function radar_visualization(config) {
 
   function legend_transform(quadrant, ring, legendColumnWidth, index=null, previousHeight = null) {
     var dx = ring < 2 ? 0 : legendColumnWidth;
-    var dy = (index == null ? -16 : index * 12);
+    var dy = (index == null ? -16 : index * 10); /// LINE HEIGTH - now shared with wrapText function XXXX
 
     if (ring % 2 === 1) {
       dy = dy + 36 + previousHeight;
@@ -374,7 +374,7 @@ function radar_visualization(config) {
 
   // Define a function for wrapping text into multiple lines
   function wrapText(text) {
-    var width = 120; // Set the width you want for wrapping
+    var width = config.legend_column_width; // Set the width you want for wrapping
     let previousElementHeight = 0;
     let previousElementY = 0;
 
@@ -403,7 +403,7 @@ function radar_visualization(config) {
           // Add a new tspan for the next line and increase the vertical offset
           tspan = textElement.append("tspan")
               .attr("x", 0)
-              .attr("dy", 10) // This ensures vertical space between lines
+              .attr("dy", 10) /// LINE HEIGTH - now shared with wrapText function XXXX
               .text(words[i]);
         }
       }

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -361,7 +361,7 @@ function radar_visualization(config) {
               .style("font-size", "11px")
               .on("mouseover", function(d) { showBubble(d); highlightLegendItem(d); })
               .on("mouseout", function(d) { hideBubble(d); unhighlightLegendItem(d); })
-              .call(wrapText)
+              .call(wrap_text)
               .each(function() {
                 previousLegendHeight += d3.select(this).node().getBBox().height;
               });
@@ -369,7 +369,7 @@ function radar_visualization(config) {
     }
   }
 
-  function wrapText(text) {
+  function wrap_text(text) {
     let heightForNextElement = 0;
 
     text.each(function() {

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -44,7 +44,7 @@ function radar_visualization(config) {
   config.title_offset = config.title_offset || { x: -675, y: -420 };
   config.footer_offset = config.footer_offset || { x: -155, y: 450 };
   config.legend_column_width = config.legend_column_width || 140
-  config.line_height = 10
+  config.legend_line_height = config.legend_line_height || 10
 
   // custom random number generator, to make random sequence reproducible
   // source: https://stackoverflow.com/questions/521295
@@ -275,7 +275,7 @@ function radar_visualization(config) {
 
   function legendTransform(quadrant, ring, legendColumnWidth, index=null, previousHeight = null) {
     const dx = ring < 2 ? 0 : legendColumnWidth;
-    let dy = (index == null ? -16 : index * config.line_height);
+    let dy = (index == null ? -16 : index * config.legend_line_height);
 
     if (ring % 2 === 1) {
       dy = dy + 36 + previousHeight;
@@ -402,7 +402,7 @@ function radar_visualization(config) {
 
           tspan = textElement.append("tspan")
               .attr("x", numberWidth)
-              .attr("dy", config.line_height)
+              .attr("dy", config.legend_line_height)
               .text(words[i]);
         }
       }

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -23,7 +23,6 @@
 
 function radar_visualization(config) {
 
-  let quadrant;
   config.svg_id = config.svg || "radar";
   config.width = config.width || 1450;
   config.height = config.height || 1000;
@@ -166,7 +165,7 @@ function radar_visualization(config) {
 
   // partition entries according to segments
   var segmented = new Array(4);
-  for (quadrant = 0; quadrant < 4; quadrant++) {
+  for (let quadrant = 0; quadrant < 4; quadrant++) {
     segmented[quadrant] = new Array(4);
     for (var ring = 0; ring < 4; ring++) {
       segmented[quadrant][ring] = [];

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -273,7 +273,7 @@ function radar_visualization(config) {
     }
   }
 
-  function legendTransform(quadrant, ring, legendColumnWidth, index=null, previousHeight = null) {
+  function legend_transform(quadrant, ring, legendColumnWidth, index=null, previousHeight = null) {
     const dx = ring < 2 ? 0 : legendColumnWidth;
     let dy = (index == null ? -16 : index * config.legend_line_height);
 
@@ -335,7 +335,7 @@ function radar_visualization(config) {
           previousLegendHeight = 0
         }
         legend.append("text")
-          .attr("transform", legendTransform(quadrant, ring, config.legend_column_width, null, previousLegendHeight))
+          .attr("transform", legend_transform(quadrant, ring, config.legend_column_width, null, previousLegendHeight))
           .text(config.rings[ring].name)
           .style("font-family", config.font_family)
           .style("font-size", "12px")
@@ -353,7 +353,7 @@ function radar_visualization(config) {
                  return (d.link && config.links_in_new_tabs) ? "_blank" : null;
               })
             .append("text")
-              .attr("transform", function(d, i) { return legendTransform(quadrant, ring, config.legend_column_width, i, previousLegendHeight); })
+              .attr("transform", function(d, i) { return legend_transform(quadrant, ring, config.legend_column_width, i, previousLegendHeight); })
               .attr("class", "legend" + quadrant + ring)
               .attr("id", function(d, i) { return "legendItem" + d.id; })
               .text(function(d) { return d.id + ". " + d.label; })
@@ -478,7 +478,7 @@ function radar_visualization(config) {
     .enter()
       .append("g")
         .attr("class", "blip")
-        .attr("transform", function(d, i) { return legendTransform(d.quadrant, d.ring, config.legend_column_width, i); })
+        .attr("transform", function(d, i) { return legend_transform(d.quadrant, d.ring, config.legend_column_width, i); })
         .on("mouseover", function(d) { showBubble(d); highlightLegendItem(d); })
         .on("mouseout", function(d) { hideBubble(d); unhighlightLegendItem(d); });
 

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -350,13 +350,56 @@ function radar_visualization(config) {
               .attr("transform", function(d, i) { return legend_transform(quadrant, ring, config.legend_column_width, i); })
               .attr("class", "legend" + quadrant + ring)
               .attr("id", function(d, i) { return "legendItem" + d.id; })
-              .text(function(d, i) { return d.id + ". " + d.label; })
+              .text(function(d, i) { return d.id + ". " + d.label; }) // XXX
               .style("font-family", config.font_family)
               .style("font-size", "11px")
               .on("mouseover", function(d) { showBubble(d); highlightLegendItem(d); })
-              .on("mouseout", function(d) { hideBubble(d); unhighlightLegendItem(d); });
+              .on("mouseout", function(d) { hideBubble(d); unhighlightLegendItem(d); })
+              .call(wrapText);
       }
     }
+  }
+
+  // Define a function for wrapping text into multiple lines
+  function wrapText(text) {
+    var width = 120; // Set the width you want for wrapping
+    let previousElementHeight = 0;
+    let previousElementY = 0;
+
+    text.each(function() {
+      var textElement = d3.select(this);
+      var words = textElement.text().split(" ");
+      var line = [];
+
+      var lineY = parseFloat(
+          previousElementY + previousElementHeight // textElement.attr("y")
+      ); // Start from the initial Y position
+
+      // Create an array of lines
+      textElement.text(null); // Remove the existing text
+      var tspan = textElement.append("tspan").attr("x", 0).attr("y", lineY).attr("dy", 0);
+      for (var i = 0; i < words.length; i++) {
+        line.push(words[i]);
+        tspan.text(line.join(" "));
+
+        // If the line is too wide, move to the next line
+        if (tspan.node().getComputedTextLength() > width) {
+          line.pop(); // Remove the word that caused the overflow
+          tspan.text(line.join(" ")); // Set the text for the previous line
+          line = [words[i]]; // Start a new line with the current word
+
+          // Add a new tspan for the next line and increase the vertical offset
+          tspan = textElement.append("tspan")
+              .attr("x", 0)
+              .attr("dy", 10) // This ensures vertical space between lines
+              .text(words[i]);
+        }
+      }
+
+      var bbox = textElement.node().getBBox();
+      previousElementHeight = bbox.height; // Get the height of the current text element
+      previousElementY = bbox.y;
+    });
   }
 
   // layer for entries

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -395,8 +395,8 @@ function radar_visualization(config) {
         line.push(words[position]);
         tspan.text(line.join(" "));
 
-        // Avoid wrap for first line (position !== 1) to end up in a situation where the long text without whitespace is wrapped
-        // (causing the first line near the legend number to be blank).
+        // Avoid wrap for first line (position !== 1) to not end up in a situation where the long text without
+        // whitespace is wrapped (causing the first line near the legend number to be blank).
         if (tspan.node().getComputedTextLength() > config.legend_column_width && position !== 1) {
           line.pop();
           tspan.text(line.join(" "));

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -274,7 +274,7 @@ function radar_visualization(config) {
 
   function legend_transform(quadrant, ring, legendColumnWidth, index=null, previousHeight = null) {
     var dx = ring < 2 ? 0 : legendColumnWidth;
-    var dy = (index == null ? -16 : index * 10); /// LINE HEIGTH - now shared with wrapText function XXXX
+    var dy = (index == null ? -16 : index * 10); /// LINE HEIGHT - now shared with wrapText function XXXX
 
     if (ring % 2 === 1) {
       dy = dy + 36 + previousHeight;
@@ -372,20 +372,21 @@ function radar_visualization(config) {
     }
   }
 
-  // Define a function for wrapping text into multiple lines
   function wrapText(text) {
-    var width = config.legend_column_width; // Set the width you want for wrapping
     let previousElementHeight = 0;
     let previousElementY = 0;
 
     text.each(function() {
-      var textElement = d3.select(this);
-      var words = textElement.text().split(" ");
-      var line = [];
+      const textElement = d3.select(this);
+      const words = textElement.text().split(" ");
+      let line = [];
 
-      var lineY = parseFloat(
-          previousElementY + previousElementHeight // textElement.attr("y")
-      ); // Start from the initial Y position
+      const lineY = previousElementY + previousElementHeight;
+
+      var number = `${textElement.text().split(".")[0]}. |`;
+      var legendNumberText = textElement.append("tspan").text(number)
+      var legendBar = textElement.append("tspan").text('|')
+      var numberWidth = legendNumberText.node().getComputedTextLength() - legendBar.node().getComputedTextLength();
 
       // Create an array of lines
       textElement.text(null); // Remove the existing text
@@ -395,20 +396,20 @@ function radar_visualization(config) {
         tspan.text(line.join(" "));
 
         // If the line is too wide, move to the next line
-        if (tspan.node().getComputedTextLength() > width) {
+        if (tspan.node().getComputedTextLength() > config.legend_column_width) {
           line.pop(); // Remove the word that caused the overflow
           tspan.text(line.join(" ")); // Set the text for the previous line
           line = [words[i]]; // Start a new line with the current word
 
           // Add a new tspan for the next line and increase the vertical offset
           tspan = textElement.append("tspan")
-              .attr("x", 0)
+              .attr("x", numberWidth)
               .attr("dy", 10) /// LINE HEIGTH - now shared with wrapText function XXXX
               .text(words[i]);
         }
       }
 
-      var bbox = textElement.node().getBBox();
+      const bbox = textElement.node().getBBox();
       previousElementHeight = bbox.height; // Get the height of the current text element
       previousElementY = bbox.y;
     });

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -272,12 +272,14 @@ function radar_visualization(config) {
     }
   }
 
-  function legend_transform(quadrant, ring, legendColumnWidth, index=null) {
+  function legend_transform(quadrant, ring, legendColumnWidth, index=null, previousHeight = null) {
     var dx = ring < 2 ? 0 : legendColumnWidth;
     var dy = (index == null ? -16 : index * 12);
+
     if (ring % 2 === 1) {
-      dy = dy + 36 + segmented[quadrant][ring-1].length * 12;
+      dy = dy + 36 + previousHeight;
     }
+
     return translate(
       config.legend_offset[quadrant].x + dx,
       config.legend_offset[quadrant].y + dy
@@ -327,9 +329,13 @@ function radar_visualization(config) {
         .style("font-family", config.font_family)
         .style("font-size", "18px")
         .style("font-weight", "bold");
+      let previosHeight = 0
       for (var ring = 0; ring < 4; ring++) {
+        if (ring % 2 === 0) {
+          previosHeight = 0
+        }
         legend.append("text")
-          .attr("transform", legend_transform(quadrant, ring, config.legend_column_width))
+          .attr("transform", legend_transform(quadrant, ring, config.legend_column_width, null, previosHeight))
           .text(config.rings[ring].name)
           .style("font-family", config.font_family)
           .style("font-size", "12px")
@@ -347,7 +353,7 @@ function radar_visualization(config) {
                  return (d.link && config.links_in_new_tabs) ? "_blank" : null;
               })
             .append("text")
-              .attr("transform", function(d, i) { return legend_transform(quadrant, ring, config.legend_column_width, i); })
+              .attr("transform", function(d, i) { return legend_transform(quadrant, ring, config.legend_column_width, i, previosHeight); })
               .attr("class", "legend" + quadrant + ring)
               .attr("id", function(d, i) { return "legendItem" + d.id; })
               .text(function(d, i) { return d.id + ". " + d.label; }) // XXX
@@ -355,7 +361,13 @@ function radar_visualization(config) {
               .style("font-size", "11px")
               .on("mouseover", function(d) { showBubble(d); highlightLegendItem(d); })
               .on("mouseout", function(d) { hideBubble(d); unhighlightLegendItem(d); })
-              .call(wrapText);
+              .call(wrapText)
+              .each(function(d, i) {
+                var textElement = d3.select(this);
+                var bbox = textElement.node().getBBox(); // Get the bounding box for the text element
+                previosHeight += bbox.height; // Add to total height
+                console.log("Total height of legend item " + d.id + ": " + bbox.height);
+              });
       }
     }
   }

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -356,7 +356,7 @@ function radar_visualization(config) {
               .attr("transform", function(d, i) { return legendTransform(quadrant, ring, config.legend_column_width, i, previousLegendHeight); })
               .attr("class", "legend" + quadrant + ring)
               .attr("id", function(d, i) { return "legendItem" + d.id; })
-              .text(function(d, i) { return d.id + ". " + d.label; }) // XXX
+              .text(function(d) { return d.id + ". " + d.label; })
               .style("font-family", config.font_family)
               .style("font-size", "11px")
               .on("mouseover", function(d) { showBubble(d); highlightLegendItem(d); })
@@ -370,15 +370,12 @@ function radar_visualization(config) {
   }
 
   function wrapText(text) {
-    let previousElementHeight = 0;
-    let previousElementY = 0;
+    let heightForNextElement = 0;
 
     text.each(function() {
       const textElement = d3.select(this);
       const words = textElement.text().split(" ");
       let line = [];
-
-      const lineY = previousElementY + previousElementHeight;
 
       const number = `${textElement.text().split(".")[0]}. |`;
       const legendNumberText = textElement.append("tspan").text(number);
@@ -390,7 +387,7 @@ function radar_visualization(config) {
       let tspan = textElement
           .append("tspan")
           .attr("x", 0)
-          .attr("y", lineY)
+          .attr("y", heightForNextElement)
           .attr("dy", 0);
 
       for (let i = 0; i < words.length; i++) {
@@ -404,14 +401,13 @@ function radar_visualization(config) {
 
           tspan = textElement.append("tspan")
               .attr("x", numberWidth)
-              .attr("dy", 10) /// LINE HEIGTH - now shared with wrapText function XXXX
+              .attr("dy", 10)
               .text(words[i]);
         }
       }
 
-      const bbox = textElement.node().getBBox();
-      previousElementHeight = bbox.height;
-      previousElementY = bbox.y;
+      const textBoundingBox = textElement.node().getBBox();
+      heightForNextElement = textBoundingBox.y + textBoundingBox.height;
     });
   }
 

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -45,7 +45,7 @@ function radar_visualization(config) {
   config.title_offset = config.title_offset || { x: -675, y: -420 };
   config.footer_offset = config.footer_offset || { x: -155, y: 450 };
   config.legend_column_width = config.legend_column_width || 140
-  config.line_height = config.line_height || 10
+  config.line_height = 10
 
   // custom random number generator, to make random sequence reproducible
   // source: https://stackoverflow.com/questions/521295
@@ -378,6 +378,7 @@ function radar_visualization(config) {
       const words = textElement.text().split(" ");
       let line = [];
 
+      // Use '|' at the end of the string so that spaces are not trimmed during rendering.
       const number = `${textElement.text().split(".")[0]}. |`;
       const legendNumberText = textElement.append("tspan").text(number);
       const legendBar = textElement.append("tspan").text('|');

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -45,6 +45,7 @@ function radar_visualization(config) {
   config.title_offset = config.title_offset || { x: -675, y: -420 };
   config.footer_offset = config.footer_offset || { x: -155, y: 450 };
   config.legend_column_width = config.legend_column_width || 140
+  config.line_height = config.line_height || 10
 
   // custom random number generator, to make random sequence reproducible
   // source: https://stackoverflow.com/questions/521295
@@ -275,7 +276,7 @@ function radar_visualization(config) {
 
   function legendTransform(quadrant, ring, legendColumnWidth, index=null, previousHeight = null) {
     const dx = ring < 2 ? 0 : legendColumnWidth;
-    let dy = (index == null ? -16 : index * 10); /// LINE HEIGHT - now shared with wrapText function XXXX
+    let dy = (index == null ? -16 : index * config.line_height);
 
     if (ring % 2 === 1) {
       dy = dy + 36 + previousHeight;
@@ -401,7 +402,7 @@ function radar_visualization(config) {
 
           tspan = textElement.append("tspan")
               .attr("x", numberWidth)
-              .attr("dy", 10)
+              .attr("dy", config.line_height)
               .text(words[i]);
         }
       }

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -391,19 +391,21 @@ function radar_visualization(config) {
           .attr("y", heightForNextElement)
           .attr("dy", 0);
 
-      for (let i = 0; i < words.length; i++) {
-        line.push(words[i]);
+      for (let position = 0; position < words.length; position++) {
+        line.push(words[position]);
         tspan.text(line.join(" "));
 
-        if (tspan.node().getComputedTextLength() > config.legend_column_width) {
+        // Avoid wrap for first line to end up in a situation where the long text without whitespace is wrapped
+        // (causing the first line near the legend number to be blank).
+        if (tspan.node().getComputedTextLength() > config.legend_column_width && position !== 1) {
           line.pop();
           tspan.text(line.join(" "));
-          line = [words[i]];
+          line = [words[position]];
 
           tspan = textElement.append("tspan")
               .attr("x", numberWidth)
               .attr("dy", config.legend_line_height)
-              .text(words[i]);
+              .text(words[position]);
         }
       }
 


### PR DESCRIPTION
Hi,

as discussed in #169,I tried to add multiline support for legend items with long names. I used `tspan` as discussed and some dynamic height calculations (based  on the bounding box (`getBBox`) + `getComputedTextLength`).
It works as expected. The items lines are aligned after the legend number.

There is still room for improvement, because we should be able to calculate the entire structure of the legends dynamically. Anyway for now, if a legend list of items is too long we should play with the parameters I added the previous PRs to fix the offset (in particular the legends offsets).
Attached you can find some example:

* the Zalando tech radar rendered, where we have an example of an item going on 2 lines
* the a video + a zip containing a working example of the Lastminute tech radar where we have a lot more items (and a lot of them going on 2 lines). Basically you can see from the code that by playing with the offset you can have "infinity legends".

I tested it carefully, but please do all the checks that you want/need on your side, and let me know if this PR makes sense and can be useful (like the previous one).
<img width="1904" alt="zalando-tech-radar-example" src="https://github.com/user-attachments/assets/6be5cea8-f85e-4974-833a-17ee3147df3a">


https://github.com/user-attachments/assets/303a2385-33c8-4a80-810d-ca46b8f59a77


[lastminute-tech-radar-example-code.zip](https://github.com/user-attachments/files/17882451/lastminute-tech-radar-example-code.zip)
