### PR TITLE
Add callout for d3.js v7 being used since 0.12 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ align on technology choices. It is based on the [pioneering work
 by ThoughtWorks](https://www.thoughtworks.com/radar).
 
 This repository contains the code to generate the visualization:
-[`radar.js`](/docs/radar.js) (based on [d3.js v4](https://d3js.org)).
+[`radar.js`](/docs/radar.js) (based on [d3.js v7](https://d3js.org)).
 Feel free to use and adapt it for your own purposes.
+
+> [!NOTE]
+> Since v0.12, we're using d3.js v7. See [related PR](https://github.com/zalando/tech-radar/pull/197/files)
+> if you need to apply changes in your fork.
 
 ## Usage
 


### PR DESCRIPTION
Also, link to the PR so that users quickly see what changes they have to apply in their forks.